### PR TITLE
gulp 'lint' now fails the process if lint errors are encountered.

### DIFF
--- a/src/rangle-gulp.js
+++ b/src/rangle-gulp.js
@@ -169,9 +169,10 @@ exports.protractor = function (options) {
 exports.jshint = function (options) {
   options = options || {};
   return function () {
-    gulp.src(options.files || defaults.allScripts)
+    return gulp.src(options.files || defaults.allScripts)
       .pipe(jshint())
-      .pipe(jshint.reporter('default'));
+      .pipe(jshint.reporter('default'))
+      .pipe(jshint.reporter('fail'));
   };
 };
 


### PR DESCRIPTION
This allows you to automate commands like

gulp lint && gulp test

or to fail builds if there are linting errors.