### PR TITLE
removed default lint task from nodemon task

### DIFF
--- a/src/rangle-gulp.js
+++ b/src/rangle-gulp.js
@@ -229,7 +229,7 @@ exports.nodemon = function (options) {
   }
   return function () {
     nodemon(nodemonOptions)
-      .on('change', options.onChange || ['lint'])
+      .on('change', options.onChange || [])
       .on('restart', function () {
         logger.info('--- Restarted the server ---');
       });


### PR DESCRIPTION
'lint' task is not not defined in rangle-gulp. if options.onChange is not defined, then the server will fail on each change